### PR TITLE
Fix load undo_delete action mapping from custom KEYFILE

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ fn str_to_action(input: String) -> Option<Action> {
         "raise_selected" => Some(Action::RaiseSelected),
         "lower_selected" => Some(Action::LowerSelected),
         "search" => Some(Action::Search),
+        "undo_delete" => Some(Action::UndoDelete),
         "help" => Some(Action::Help),
         _ => None,
     }


### PR DESCRIPTION
The config loader doesn't contemplate the undo_delete binding. This PR adds support to remap such action.