### PR TITLE
std::env::home_dir is deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "test/test.rs"
 default = []
 
 [dependencies]
+dirs="1.0"
 termion = "1.1"
 log = "0.3"
 lazy_static = "0.2"

--- a/src/bin/void.rs
+++ b/src/bin/void.rs
@@ -1,5 +1,6 @@
 extern crate getopts;
 extern crate fs2;
+extern crate dirs;
 extern crate voidmap;
 
 #[macro_use]
@@ -22,7 +23,7 @@ fn main() {
 
     let mut args: Vec<String> = std::env::args().collect();
     let program = args.remove(0);
-    let default = std::env::home_dir().and_then(|mut h| {
+    let default = dirs::home_dir().and_then(|mut h| {
         h.push(".void.db");
         h.to_str().map(|p| p.to_owned())
     });


### PR DESCRIPTION
`std::env::home_dir` has been deprecated since 1.29.0, and the official documentation (https://doc.rust-lang.org/std/env/fn.home_dir.html) points to https://crates.io/crates/dirs, which has a simple drop-in replacement.